### PR TITLE
Add TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
     "lint-fix": "eslint src --fix",
     "test": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha",
     "closetest": "babel-node ./example/close.js",
+    "dtslint": "dtslint types",
     "s3test": "babel-node ./example/s3test.js",
     "build": "npm run lint && npm run test && babel src  --ignore __tests__ --out-dir dist/ && cp package.json dist/ && cp README.md dist/"
   },
   "devDependencies": {
+    "@types/node": "14.14.31",
     "aws-sdk": "^2.417.0",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.1.2",
@@ -38,8 +40,11 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
+    "dtslint": "4.0.7",
     "eslint": "^4.14.0",
     "eslint-plugin-babel": "^4.1.2",
-    "mocha": "^4.1.0"
-  }
+    "mocha": "^4.1.0",
+    "typescript": "4.2.2"
+  },
+  "types": "types"
 }

--- a/package.json
+++ b/package.json
@@ -21,13 +21,15 @@
     "url": "https://github.com/bhoriuchi/readline-promise/issues"
   },
   "scripts": {
-    "lint": "eslint src",
-    "lint-fix": "eslint src --fix",
-    "test": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha",
+    "build": "npm run lint && npm run test && babel src  --ignore __tests__ --out-dir dist/",
     "closetest": "babel-node ./example/close.js",
     "dtslint": "dtslint types",
+    "lint": "eslint src",
+    "lint-fix": "eslint src --fix",
+    "prebuild": "rm -rf dist",
+    "postbuild": "cp package.json dist && cp README.md dist && mkdir -p dist/types && cp types/index.d.ts dist/types",
     "s3test": "babel-node ./example/s3test.js",
-    "build": "npm run lint && npm run test && babel src  --ignore __tests__ --out-dir dist/ && cp package.json dist/ && cp README.md dist/"
+    "test": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha"
   },
   "devDependencies": {
     "@types/node": "14.14.31",

--- a/types/index.d.test.ts
+++ b/types/index.d.test.ts
@@ -1,0 +1,33 @@
+import readline from "readline-promise";
+
+const rlp = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+// $ExpectType Promise<void>[]
+rlp.each(async (_line: string, _index: number, _lines: string[]) => {});
+
+// $ExpectError
+rlp.each((_line: string, _index: number, _lines: string[]) => {});
+
+// $ExpectType Promise<void>[]
+rlp.forEach(async (_line: string, _index: number, _lines: string[]) => {});
+
+// $ExpectError
+rlp.forEach((_line: string, _index: number, _lines: string[]) => {});
+
+// $ExpectType Promise<string>[]
+rlp.map(async (line: string, _index: number, _lines: string[]) => line);
+
+// $ExpectError
+rlp.map((line: string, _index: number, _lines: string[]) => line);
+
+// $ExpectType Promise<string>
+rlp.questionAsync("Async?");
+
+// $ExpectError
+rlp.questionAsync(1234);
+
+// $ExpectType Promise<string>
+rlp.reduce(async (_accumulator: string, line: string, _index: number, _lines: string[]) => line, "initial");
+
+// $ExpectError
+rlp.reduce((_accumulator: string, line: string, _index: number, _lines: string[]) => line, "initial");

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,29 @@
+import { Interface, ReadLineOptions } from "readline";
+
+type AsyncIteratee<TReturn = void> = (
+    line: string,
+    index: number,
+    lines: string[]
+) => Promise<TReturn>;
+
+interface AsyncInterface extends Interface {
+    each: (iteratee: AsyncIteratee) => Array<Promise<void>>;
+    forEach: (iteratee: AsyncIteratee) => Array<Promise<void>>;
+    map: (iteratee: AsyncIteratee<string>) => Array<Promise<string>>;
+    questionAsync: (question: string) => Promise<string>;
+    reduce: (iteratee: (
+        accumulator: string,
+        line: string,
+        index: number,
+        lines: string[]
+    ) => Promise<string>, accumulator?: string) => Promise<string>;
+}
+
+declare class ReadlinePromise extends Interface {
+    createInterface(options: ReadLineOptions): AsyncInterface;
+}
+
+declare const readline: ReadlinePromise;
+
+export { AsyncIteratee, AsyncInterface };
+export default readline;

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "esModuleInterop": true,
+        "lib": ["es6"],
+        "module": "commonjs",
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "paths": {
+            "readline-promise": ["."]
+        },
+        "strictFunctionTypes": true,
+        "strictNullChecks": true
+    }
+}


### PR DESCRIPTION
Resolves #11 Request: TypeScript definitions

- Add type definitions for async readline functions, add typescript + dtslint dev dependencies for testing definitions
- Update build scripts to clean and copy additional assets (incl. types) before/after babel runs

Let me know if there's anything that seems off here. I'm not super familiar with the `reduce` function signature, so that may need tweaking. Didn't want to introduce too much in one PR, but would it make sense to include the `dtslint` or other example tests in the main `test` script?