### PR TITLE
[Refactor] updates- changed the promise.then to await 

### DIFF
--- a/src/__tests__/readline-test.js
+++ b/src/__tests__/readline-test.js
@@ -5,67 +5,59 @@ import fs from 'fs';
 import path from 'path';
 
 describe('readline-promise tests', function () {
-  it('reduce test', function () {
+  it('reduce test', async function () {
     const filePath = path.resolve(__dirname, 'file.txt');
     const rlp = readline.createInterface({
       terminal: false,
       input: fs.createReadStream(filePath)
     });
-    return rlp.reduce((accum, line, index) => {
+    const total = await rlp.reduce((accum, line, index) => {
       expect(line).to.equal(String(index + 1));
       return accum + Number(line);
-    }, 0)
-    .then(total => {
-      expect(total).to.equal(15);
-    });
+    }, 0);
+    expect(total).to.equal(15);
   });
 
-  it('each/forEach test', function () {
+  it('each/forEach test', async function () {
     const filePath = path.resolve(__dirname, 'file.txt');
     const rlp = readline.createInterface({
       terminal: false,
       input: fs.createReadStream(filePath)
     });
-    return rlp.each((line, index) => {
+    const lines = await rlp.each((line, index) => {
       expect(line).to.equal(String(index + 1));
-    })
-    .then(lines => {
-      expect(lines).to.equal(undefined);
     });
+    expect(lines).to.equal(undefined);
   });
 
-  it('map test', function () {
+  it('map test', async function () {
     const filePath = path.resolve(__dirname, 'file.txt');
     const rlp = readline.createInterface({
       terminal: false,
       input: fs.createReadStream(filePath)
     });
-    return rlp.map((line, index) => {
+    const lines = await rlp.map((line, index) => {
       expect(line).to.equal(String(index + 1));
       return Number(line);
-    })
-    .then(lines => {
-      expect(lines).to.deep.equal([ 1, 2, 3, 4, 5 ]);
     });
+    expect(lines).to.deep.equal([1, 2, 3, 4, 5]);
   });
 
-  it('zero length test', function () {
+  it('zero length test', async function () {
     const values = [ 'foo', '', 'bar', 'baz' ];
     const filePath = path.resolve(__dirname, 'zero-file.txt');
     const rlp = readline.createInterface({
       terminal: false,
       input: fs.createReadStream(filePath)
     });
-    return rlp.map((line, index) => {
+    const lines = await rlp.map((line, index) => {
       expect(line).to.equal(values[index]);
       return line;
-    })
-    .then(lines => {
-      expect(lines).to.deep.equal(values);
     });
+    expect(lines).to.deep.equal(values);
   });
 
-  it('questionAsync test', function () {
+  it('questionAsync test', async function () {
     // this.timeout(10000);
     const rlp = readline.createInterface({
       input: process.stdin,
@@ -76,14 +68,12 @@ describe('readline-promise tests', function () {
       rlp.write('pong\r');
     }, 100);
 
-    return rlp.questionAsync('ping: ')
-      .then(answer => {
-        expect(answer).to.equal('pong');
-        rlp.close();
-      });
+    const answer = await rlp.questionAsync('ping: ');
+    expect(answer).to.equal('pong');
+    rlp.close();
   });
 
-  it('questionAsync terminal test', function () {
+  it('questionAsync terminal test', async function () {
     // this.timeout(10000);
     const rlp = readline.createInterface({
       input: process.stdin,
@@ -95,11 +85,9 @@ describe('readline-promise tests', function () {
       rlp.write('pong\r');
     }, 100);
 
-    return rlp.questionAsync('ping: ')
-      .then(answer => {
-        expect(answer).to.equal('pong');
-        rlp.close();
-      });
+    const answer = await rlp.questionAsync('ping: ');
+    expect(answer).to.equal('pong');
+    rlp.close();
   });
 
   it('await questionAsync terminal test', async function () {


### PR DESCRIPTION
1. removed .thens and added/replaced them with async-await


PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ]  Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Docs
- [ ] Other... Please describe:


What is the current behavior?
The test cases were using Promise.then. changed it from Promise.then to async-await

prior-refactor
![image](https://user-images.githubusercontent.com/31963345/114303549-44133180-9aec-11eb-936f-28bc5d68bde6.png)
post-refactor
![image](https://user-images.githubusercontent.com/31963345/114303559-555c3e00-9aec-11eb-93f1-0be6c65672a1.png)


Issue Number: N/A

What is the new behavior?
![image](https://user-images.githubusercontent.com/31963345/114303568-6b69fe80-9aec-11eb-9fc4-1f3677a5c547.png)

changed the Promise.then to await

Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

@bhoriuchi please review.
Thank you for your time 😄  