### PR TITLE
Fix unresolved types

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ A drop in replacement for readline with additional promise based methods like `m
 
 Note: If you were using `var readline = require('readline')`, change this to `var readline = require('readline-promise').default`.
 
+## Typescript
+For typescript to find the corresponding types set your project's `tsconfig` to use node module resolution
+
+```json
+{
+  "compilerOptions": {
+    /* Rest of the config */
+    "moduleResolution": "node", 
+  }
+}
+```
+
+
 ## Example
 ```js
 import readline from 'readline-promise';

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.5",
   "description": "Readline using promises",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bhoriuchi/readline-promise.git"
@@ -27,7 +28,7 @@
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",
     "prebuild": "rm -rf dist",
-    "postbuild": "cp package.json dist && cp README.md dist && mkdir -p dist/types && cp types/index.d.ts dist/types",
+    "postbuild": "cp package.json dist && cp README.md dist && cp types/index.d.ts dist",
     "s3test": "babel-node ./example/s3test.js",
     "test": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha"
   },
@@ -47,6 +48,5 @@
     "eslint-plugin-babel": "^4.1.2",
     "mocha": "^4.1.0",
     "typescript": "4.2.2"
-  },
-  "types": "types"
+  }
 }


### PR DESCRIPTION
Since this package seems to be deployed from the `dist` folder I moved the types to the "root" being the root of dist. This is because when the package is installed on other projects it seems that TypeScript cannot find the types from the `types` subfolder. Also added a little note for other users to change their tsconfig module resolution to `node`. Otherwise the types are not found.

If this gets merged, it might be good idea to create a whole new release, so that the release tags on github align with the release numbers on npm